### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 **Official MCP client for Buildable - AI-powered development platform that makes any project buildable**
 
+<a href="https://glama.ai/mcp/servers/@chunkydotdev/bldbl-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@chunkydotdev/bldbl-mcp/badge" alt="@bldbl/mcp MCP server" />
+</a>
+
 [![npm version](https://badge.fury.io/js/@bldbl%2Fmcp.svg)](https://badge.fury.io/js/@bldbl%2Fmcp)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
@@ -368,4 +372,4 @@ This software is proprietary and confidential. Unauthorized copying, distributio
 
 ---
 
-**Built with ❤️ by the BuildPlanner team** 
+**Built with ❤️ by the BuildPlanner team**


### PR DESCRIPTION
This PR adds a badge for the [@bldbl/mcp](https://glama.ai/mcp/servers/@chunkydotdev/bldbl-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@chunkydotdev/bldbl-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@chunkydotdev/bldbl-mcp/badge" alt="@bldbl/mcp MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.